### PR TITLE
2019.2 Update (Linux)

### DIFF
--- a/linux/tableau-server-backup.bash
+++ b/linux/tableau-server-backup.bash
@@ -68,24 +68,22 @@ echo $TIMESTAMP "The path for storing backups is $backup_path"
 
 # count the number of backup files eligible for deletion and output 
 echo $TIMESTAMP "Cleaning up old backups..."
-lines=$(find $backup_path -type f -name '*.tsbak' -mtime +$backup_days | wc -l)
+lines=$(find $backup_path -type f -regex '.*.\(tsbak\|json\)' -mtime +$backup_days | wc -l)
 if [ $lines -eq 0 ]; then 
 	echo $TIMESTAMP $lines old backups found, skipping...
-	else $TIMESTAMP $lines old backups found, deleting...
+	else echo  $TIMESTAMP $lines old backups found, deleting...
 		#remove backup files older than N days
-		find $backup_path -type f -name '*.tsbak' -mtime +$backup_days -exec rm {} \;
+		find $backup_path -type f -regex '.*.\(tsbak\|json\)' -mtime +$backup_days -exec rm {} \;
 fi
 
 #export current settings
 echo $TIMESTAMP "Exporting current settings..."
-tsm settings export -f $backup_path/settings.json $tsmparams
-
+tsm settings export -f $backup_path/settings-$DATE.json $tsmparams
 #create current backup
 echo $TIMESTAMP "Backup up Tableau Server data..."
 tsm maintenance backup -f $backup_name -d $tsmparams
-
 #copy backups to different location (optional)
-if [ "$copybackup" == "yes" ];
+if [ "$copy_backup" == "yes" ];
 	then
 	echo $TIMESTAMP "Copying backup and settings to remote share"
 	cp $backup_path/* $external_backup_path/

--- a/linux/tableau-server-housekeeping-linux.bash
+++ b/linux/tableau-server-housekeeping-linux.bash
@@ -120,17 +120,17 @@ echo $TIMESTAMP "The path for storing backups is $backup_path"
 
 # count the number of backup files eligible for deletion and output 
 echo $TIMESTAMP "Cleaning up old backups..."
-lines=$(find $backup_path -type f -name '*.tsbak' -mtime +$backup_days | wc -l)
+lines=$(find $backup_path -type f -regex '.*.\(tsbak\|json\)' -mtime +$backup_days | wc -l)
 if [ $lines -eq 0 ]; then 
 	echo $TIMESTAMP $lines old backups found, skipping...
 	else echo  $TIMESTAMP $lines old backups found, deleting...
 		#remove backup files older than N days
-		find $backup_path -type f -name '*.tsbak' -mtime +$backup_days -exec rm {} \;
+		find $backup_path -type f -regex '.*.\(tsbak\|json\)' -mtime +$backup_days -exec rm {} \;
 fi
 
 #export current settings
 echo $TIMESTAMP "Exporting current settings..."
-tsm settings export -f $backup_path/settings.json $tsmparams
+tsm settings export -f $backup_path/settings-$DATE.json $tsmparams
 #create current backup
 echo $TIMESTAMP "Backup up Tableau Server data..."
 tsm maintenance backup -f $backup_name -d $tsmparams

--- a/linux/tableau-server-housekeeping-linux.bash
+++ b/linux/tableau-server-housekeeping-linux.bash
@@ -6,14 +6,15 @@
 # 		Run the setup script to fetch the script and install it in your system correctly 
 #
 #		Test that the script works in your environment by running it manually
-#			You must execute the script as a user that is a member of the tsmadmin group
-#			sudo su -l <tsmusername> -c /var/opt/tableau/tableau_server/scripts/tableau-server-housekeeping.sh <tsmusername> <tsmpassword>
 #
-#		NOTE you have to add your tsm username and password at the end of the command to execute the script. 
+#		NOTE If Server release is behind 2019.2, you have to add your tsm username and password at the end of the command to execute the script. 
 #			This avoids you having to hardcode credentials into the script itself
+#
+#				sudo su -l <tsmusername> -c /var/opt/tableau/tableau_server/scripts/tableau-server-housekeeping.sh <tsmusername> <tsmpassword>
 #
 #		*UPDATE* starting in 2019.2 the above requirement to include credentials will no longer be necessary,
 # 			provided the user executing the script is a member of the tsmadmin group  
+#				sudo su -l <tsmusername> -c /var/opt/tableau/tableau_server/scripts/tableau-server-housekeeping.sh
 #
 #		Schedule the script using cron to run on a regular basis
 #			sudo su -l $tsmuser -c "crontab -e"
@@ -49,12 +50,6 @@ log_name="logs"
 
 # LOAD ENVIRONMENT & USER INPUT
 
-# Get tsm username from command line
-tsmuser=$1
-
-# Get tsm password from command line
-tsmpassword=$2 
-
 # Load the Tableau Server environment variables into the cron environment
 source /etc/profile.d/tableau_server.sh
 
@@ -66,10 +61,21 @@ load_environment_file() {
   fi
 }
 
+if [ "$#" -eq 2 ] ; then
+	# Get tsm username from command line input
+	tsmuser="$1"
+	# Get tsm password from command line input
+	tsmpassword="$2" 
+	tsmparams="-u $tsmuser -p $tsmpassword"
+elif [ $(echo $TABLEAU_SERVER_DATA_DIR_VERSION | cut -d. -f1) -ge 20192 ]  && (id -nG | grep -q tsmadmin || [ ${EUID} -eq 0 ]) ; then 
+	# 2019.2 workflow. If running as tsmadmin member or root, do not set userinfo
+	declare tsmparams
+fi
+
 # LOGS SECTION
 
 # get the path to the log archive folder
-log_path=$(tsm configuration get -k basefilepath.log_archive -u $tsmuser -p $tsmpassword)
+log_path=$(tsm configuration get -k basefilepath.log_archive $tsmparams)
 echo $TIMESTAMP "The path for storing log archives is $log_path" 
 
 # count the number of log files eligible for deletion and output 
@@ -78,7 +84,7 @@ lines=$(find $log_path -type f -name '*.zip' -mtime +$log_days | wc -l)
 if [ $lines -eq 0 ]; then 
 	echo $TIMESTAMP $lines found, skipping...
 	
-	else $TIMESTAMP $lines found, deleting...
+	else echo $TIMESTAMP $lines found, deleting...
 		#remove log archives older than the specified number of days
 		find $log_path -type f -name '*.zip' -mtime +$log_days -exec rm {} \;
 	echo $TIMESTAMP "Cleaning up completed."		
@@ -86,7 +92,7 @@ fi
 
 #archive current logs 
 echo $TIMESTAMP "Archiving current logs..."
-tsm maintenance ziplogs -a -t -o -f logs-$DATE.zip -u $tsmuser -p $tsmpassword
+tsm maintenance ziplogs -a -t -o -f logs-$DATE.zip $tsmparams
 #copy logs to different location (optional)
 if [ "$copylogs" == "yes" ];
 	then
@@ -99,7 +105,7 @@ fi
 # BACKUP SECTION
 
 # get the path to the backups folder
-backup_path=$(tsm configuration get -k basefilepath.backuprestore -u $tsmuser -p $tsmpassword)
+backup_path=$(tsm configuration get -k basefilepath.backuprestore $tsmparams)
 echo $TIMESTAMP "The path for storing backups is $backup_path" 
 
 # count the number of backup files eligible for deletion and output 
@@ -107,19 +113,19 @@ echo $TIMESTAMP "Cleaning up old backups..."
 lines=$(find $backup_path -type f -name '*.tsbak' -mtime +$backup_days | wc -l)
 if [ $lines -eq 0 ]; then 
 	echo $TIMESTAMP $lines old backups found, skipping...
-	else $TIMESTAMP $lines old backups found, deleting...
+	else echo  $TIMESTAMP $lines old backups found, deleting...
 		#remove backup files older than N days
 		find $backup_path -type f -name '*.tsbak' -mtime +$backup_days -exec rm {} \;
 fi
 
 #export current settings
 echo $TIMESTAMP "Exporting current settings..."
-tsm settings export -f $backup_path/settings.json -u $tsmuser -p $tsmpassword
+tsm settings export -f $backup_path/settings.json $tsmparams
 #create current backup
 echo $TIMESTAMP "Backup up Tableau Server data..."
-tsm maintenance backup -f $backup_name -d -u $tsmuser -p $tsmpassword
+tsm maintenance backup -f $backup_name -d $tsmparams
 #copy backups to different location (optional)
-if [ "$copybackup" == "yes" ];
+if [ "$copy_backup" == "yes" ];
 	then
 	echo $TIMESTAMP "Copying backup and settings to remote share"
 	cp $backup_path/* $external_backup_path/
@@ -131,10 +137,10 @@ fi
 
 # cleanup old logs and temp files 
 echo $TIMESTAMP "Cleaning up Tableau Server..."
-tsm maintenance cleanup -a -u $tsmuser -p $tsmpassword
+tsm maintenance cleanup -a $tsmparams
 # restart the server (optional, uncomment to run)
 	#echo "Restarting Tableau Server"
-	#tsm restart -u $tsmuser -p $tsmpassword
+	#tsm restart $tsmparams
 
 # END OF CLEANUP AND RESTART SECTION
 

--- a/linux/tableau-server-housekeeping-linux.bash
+++ b/linux/tableau-server-housekeeping-linux.bash
@@ -102,6 +102,16 @@ fi
 
 # END OF LOGS SECTION
 
+
+# CLEANUP SECTION
+
+# cleanup old logs and temp files 
+echo $TIMESTAMP "Cleaning up Tableau Server..."
+tsm maintenance cleanup -a $tsmparams
+
+# END OF CLEANUP SECTION
+
+
 # BACKUP SECTION
 
 # get the path to the backups folder
@@ -133,16 +143,13 @@ fi
 
 # END OF BACKUP SECTION
 
-# CLEANUP AND RESTART SECTION
+# RESTART SECTION
 
-# cleanup old logs and temp files 
-echo $TIMESTAMP "Cleaning up Tableau Server..."
-tsm maintenance cleanup -a $tsmparams
 # restart the server (optional, uncomment to run)
 	#echo "Restarting Tableau Server"
 	#tsm restart $tsmparams
 
-# END OF CLEANUP AND RESTART SECTION
+# END OF RESTART SECTION
 
 # END OF SCRIPT
 echo $TIMESTAMP "Housekeeping completed"


### PR DESCRIPTION
- Typos fixed. 
- Credential provisioning are set to be optional for Server releases since 2019.2
- As it described in in [official docs](https://onlinehelp.tableau.com/current/server-linux/en-us/db_backup.htm#script-the-backup-process), flow has been changed from backup-cleanup to cleanup-backup.