### PR TITLE
linux variable reference: copy_backup

### DIFF
--- a/linux/tableau-server-backup.bash
+++ b/linux/tableau-server-backup.bash
@@ -79,7 +79,7 @@ echo $TIMESTAMP "Backup up Tableau Server data..."
 tsm maintenance backup -f $backup_name -d -u $tsmuser -p $tsmpassword
 
 #copy backups to different location (optional)
-if [ "$copybackup" == "yes" ];
+if [ "$copy_backup" == "yes" ];
 	then
 	echo $TIMESTAMP "Copying backup and settings to remote share"
 	cp $backup_path/* $external_backup_path/


### PR DESCRIPTION
copy_backup failed because the incorrect variable name is used on line 82.