### PR TITLE
replace ziplogs flags -mi -t with -a

### DIFF
--- a/windows/2018.2 to 2019.1/tableau-server-log-archive-script.cmd
+++ b/windows/2018.2 to 2019.1/tableau-server-log-archive-script.cmd
@@ -106,7 +106,7 @@ FORFILES -p "%archivepath%" -s -m *.zip /D -%archivedays% /C "cmd /c del @path" 
 :: Then we archive the logs
 :archive
 ECHO %date% %time% : Archiving Tableau Server log files
-CALL tsm maintenance ziplogs -mi -t -o -f logs-%mydate% -u %tsmadmin% -p %tsmpassword%
+CALL tsm maintenance ziplogs -a -o -f logs-%mydate% -u %tsmadmin% -p %tsmpassword%
 
 :end_msg
 IF %ERRORLEVEL% EQU 0 (

--- a/windows/2019.2 and later/tableau-server-log-archive-script.cmd
+++ b/windows/2019.2 and later/tableau-server-log-archive-script.cmd
@@ -76,7 +76,7 @@ FORFILES -p "%archivepath%" -s -m *.zip /D -%archivedays% /C "cmd /c del @path" 
 :: Then we archive the logs
 :archive
 ECHO %date% %time% : Archiving Tableau Server log files
-CALL tsm maintenance ziplogs -mi -t -o -f logs-%mydate%
+CALL tsm maintenance ziplogs -a -o -f logs-%mydate%
 
 :end_msg
 IF %ERRORLEVEL% EQU 0 (


### PR DESCRIPTION
by default, ziplogs will collect a maximum of two days of log files. a weekly archive and cleanup would remove all seven days but only store the most recent two. changing to `-a` ensures that all logs are retained in the archive, so a weekly archive and cleanup isn't lossy.

this appears to have already been done in the linux scripts.