### PR TITLE
fix(tableau-server-linux-backup): do not proceed when tsm raises error

### DIFF
--- a/linux/tableau-server-backup.bash
+++ b/linux/tableau-server-backup.bash
@@ -70,8 +70,9 @@ backup_path=$(tsm configuration get -k basefilepath.backuprestore $tsmparams)
 # If tsm command output is not as expected, raise an error and exit the script
 RESULT=$?
 if [ $RESULT -ne 0 ]; then
-        echo "Something is not correct with tsm command and the output is not as expected!"
-        echo "Backup process didn't start because of an error. Exiting ..."
+        echo "Something is wrong with tsm command!"
+        echo "Error in setting backup_path:" $backup_path
+        echo "Backup process did not start. Exiting..."
         exit $RESULT
 fi
 

--- a/linux/tableau-server-backup.bash
+++ b/linux/tableau-server-backup.bash
@@ -66,6 +66,15 @@ fi
 
 # get the path to the backups folder
 backup_path=$(tsm configuration get -k basefilepath.backuprestore $tsmparams)
+
+# If tsm command output is not as expected, raise an error and exit the script
+RESULT=$?
+if [ $RESULT -ne 0 ]; then
+        echo "Something is not correct with tsm command and the output is not as expected!"
+        echo "Backup process didn't start because of an error. Exiting ..."
+        exit $RESULT
+fi
+
 TIMESTAMP=`date '+%Y-%m-%d %H:%M:%S'`
 echo $TIMESTAMP "The path for storing backups is $backup_path" 
 


### PR DESCRIPTION
A couple of weeks ago, we saw some errors in our backup process. By drilling down, we found out that the `tsm` command was not working correctly (because of issues on the server side). So, instead of returning the expected output, it returned some error logs. And on the later step (when it cleans up the old backups), it was trying to clean up the path which didn't exist (and it can be risky as well since it may delete some critical files/folders). 

TLDR
If `tsm` command output has an error, exit and don't continue the script. 